### PR TITLE
Expose external RAM through retro_get_memory_data

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -103,7 +103,7 @@ static char scshot[MAXC],
 odyssey2[MAXC],
 file_v[MAXC],scorefile[MAXC], statefile[MAXC];
 
-extern uint8_t intRAM[];
+extern uint8_t ram[];
 
 // True if the virtual keyboard must be showed
 static bool vkb_show = false;
@@ -1088,14 +1088,14 @@ unsigned retro_api_version(void)
 void *retro_get_memory_data(unsigned id)
 {
     if ( id == RETRO_MEMORY_SYSTEM_RAM )
-        return intRAM;
+        return ram;
     return NULL;
 }
 
 size_t retro_get_memory_size(unsigned id)
 {
     if ( id == RETRO_MEMORY_SYSTEM_RAM )
-        return 64;
+        return 64 + 256;
     return 0;
 }
 

--- a/src/vmachine.c
+++ b/src/vmachine.c
@@ -66,8 +66,9 @@ int tweakedaudio=0;
 
 uint8_t rom_table[8][4096];
 
-uint8_t intRAM[64];
-uint8_t extRAM[256];
+uint8_t ram[64 + 256];
+uint8_t *intRAM = ram;
+uint8_t *extRAM = &ram[64];
 uint8_t extROM[1024];
 uint8_t VDCwrite[256];
 uint8_t ColorVector[MAXLINES];

--- a/src/vmachine.h
+++ b/src/vmachine.h
@@ -34,8 +34,8 @@ extern uint8_t coltab[256];
 extern int mstate;
 
 extern uint8_t rom_table[8][4096];
-extern uint8_t intRAM[];
-extern uint8_t extRAM[];
+extern uint8_t *intRAM;
+extern uint8_t *extRAM;
 extern uint8_t extROM[];
 extern uint8_t VDCwrite[256];
 extern uint8_t ColorVector[MAXLINES];


### PR DESCRIPTION
The core only exposed the internal RAM, but many games make extensive use of the external RAM as well. Having no access to it is a problem for developing achievements.

External RAM is now exposed through `RETRO_MEMORY_SYSTEM_RAM`, right after the internal RAM. This memory map is virtual, as the console itself accesses the two RAMs using specific instructions instead of mapping them to a single address space.