### PR TITLE
emscripten: disable voice support (build fix)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ else ifeq ($(platform), vita)
 else ifeq ($(platform), emscripten)
    TARGET := $(TARGET_NAME)_libretro_$(platform).bc
    STATIC_LINKING = 1
+   HAVE_VOICE = 0
 
 # Nintendo Game Cube / Wii / WiiU
 else ifneq (,$(filter $(platform), ngc wii wiiu))


### PR DESCRIPTION
The emscripten build is currently failing because it is incompatible with 'The Voice' implementation (the emscripten RA frontend does not include the required dependencies). This PR simply disables voice support for emscripten.