### PR TITLE
Fix O2 "Clear" and "Reset" keys.

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -526,7 +526,7 @@ static void update_input(void)
       key[RETROK_SPACE]    = input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_SPACE);       /* Space */
       key[RETROK_QUESTION] = input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_QUESTION); /* ? */
       key[RETROK_PERIOD]   = input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_PERIOD);     /* . */
-      key[RETROK_END]      = input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_END);           /* "Clear" */
+      key[RETROK_DELETE]   = input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_END);           /* "Clear" */
       key[RETROK_RETURN]   = input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_RETURN);     /* "Enter" */
       key[RETROK_MINUS]    = input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_MINUS);       /* - */
       key[RETROK_ASTERISK] = input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_ASTERISK); /* Multiply sign */
@@ -538,6 +538,13 @@ static void update_input(void)
 done:
    /* Virtual keyboard management */
    update_input_virtual_keyboard(joypad_bits[0]);
+
+   /* Take into account RESET being pressed (F5 is O2EM original setting )*/
+   if (key[RETROK_F5] || input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_F5))
+   {
+       retro_reset();
+       key[RETROK_F5] = 0;
+   }	
 }
 
 static void upate_audio(void)

--- a/src/vkeyb/vkeyb_layout.c
+++ b/src/vkeyb/vkeyb_layout.c
@@ -26,9 +26,9 @@ const struct VKey o2_kb[ODYSSEY2_KB_KEYS] =
   { RETROK_EQUALS, 138,  44, 31, 16, &o2_kb[13], &o2_kb[15], &o2_kb[4],  &o2_kb[24] }, /* 14: = */
   { RETROK_LALT, 170,  44, 31, 16, &o2_kb[14], &o2_kb[16], &o2_kb[5],  &o2_kb[25] }, /* 15: YES */
   { RETROK_RALT, 202,  44, 31, 16, &o2_kb[15], &o2_kb[17], &o2_kb[6],  &o2_kb[26] }, /* 16: NO */
-  { RETROK_END, 234,  44, 31, 16, &o2_kb[16], &o2_kb[18], &o2_kb[7],  &o2_kb[27] }, /* 17: CLEAR */
+  { RETROK_DELETE, 234,  44, 31, 16, &o2_kb[16], &o2_kb[18], &o2_kb[7],  &o2_kb[27] }, /* 17: CLEAR */
   { RETROK_RETURN, 266,  44, 31, 16, &o2_kb[17], &o2_kb[19], &o2_kb[8],  &o2_kb[28] }, /* 18: ENTER */
-  { RETROK_UNKNOWN, 299,  44, 31, 16, &o2_kb[18], &o2_kb[10], &o2_kb[9],  &o2_kb[29] }, /* 19: RESET */
+  { RETROK_F5, 299,  44, 31, 16, &o2_kb[18], &o2_kb[10], &o2_kb[9],  &o2_kb[29] }, /* 19: RESET */
   // 3rd row (keys 20 to 29)
   { RETROK_q,   8,  87, 32, 17, &o2_kb[29], &o2_kb[21], &o2_kb[10], &o2_kb[30] }, /* 20: Q */
   { RETROK_w,  41,  87, 32, 17, &o2_kb[20], &o2_kb[22], &o2_kb[11], &o2_kb[31] }, /* 21: W */

--- a/src/vmachine.c
+++ b/src/vmachine.c
@@ -133,7 +133,7 @@ static unsigned int key_map[6][8]= {
       RETROK_EQUALS,
       RETROK_y,
       RETROK_n,
-      RETROK_END,
+      RETROK_DELETE,
       RETROK_RETURN
    }
 };
@@ -484,8 +484,10 @@ uint8_t read_P2(void)
          {
             int km = key_map[si][i];
             //FIXME
-            if ( key[km] && (!joykeystab[km]))
-               so = i ^ 0x07;
+            if (km > 127 && key[km])
+                so = i & 0x07;
+            else if ( key[km] && (!joykeystab[km]))
+                so = i ^ 0x07;
          }
       }
       if (so != 0xff)


### PR DESCRIPTION
Change "Clear" key from "END" to "DELETE" and "Reset" back to F5 as in original O2EM.  Now "Clear" key and "Reset" key on keyboard and virtual keyboard work correctly.  Put code in to reset O2 when F5 is pressed.